### PR TITLE
chore: Add Gatsby 5 to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "main": "./index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "homepage": "https://github.com/JimmyBeldone/gatsby-plugin-webpack-bundle-analyser-v2",
   "repository": {


### PR DESCRIPTION
Hi!

We released Gatsby 5 yesterday, no relevant changes for this plugin. So it's safe to just add the version range to peerDeps.

Thanks for maintaining the plugin!